### PR TITLE
cake: tc shows number of active flows within class

### DIFF
--- a/include/linux/pkt_sched.h
+++ b/include/linux/pkt_sched.h
@@ -922,7 +922,7 @@ struct tc_cake_xstats {
 		__u32 peak_delay; /* delay to fat flows */
 		__u32 avge_delay;
 		__u32 base_delay; /* delay to sparse flows */
-		__u32 dummy2;
+		__u32 active_flows;
 	} cls[8];
 };
 

--- a/tc/q_cake.c
+++ b/tc/q_cake.c
@@ -402,6 +402,11 @@ static int cake_print_xstats(struct qdisc_util *qu, FILE *f,
 			fprintf(f, "%12llu", stc->cls[i].bytes);
 		fprintf(f, "\n");
 
+		fprintf(f, "  flows ");
+		for(i=0; i < stc->class_cnt; i++)
+			fprintf(f, "%12u", stc->cls[i].active_flows);
+		fprintf(f, "\n");
+
 		fprintf(f, "  drops ");
 		for(i=0; i < stc->class_cnt; i++)
 			fprintf(f, "%12u", stc->cls[i].dropped);


### PR DESCRIPTION
Hi Dave,

A small tweak with tc to show the number of active flows from cake.  Update to pkt_sched.h to match sch_cake's idea of the structure.

Kevin
