### PR TITLE
drop last_len stat

### DIFF
--- a/tc/q_cake.c
+++ b/tc/q_cake.c
@@ -577,10 +577,12 @@ static int cake_print_xstats(struct qdisc_util *qu, FILE *f,
 			fprintf(f, "%12u", stnc->bulk_flows[i]);
 		fprintf(f, "\n");
 
-		fprintf(f, "  last_len");
-		for(i=0; i < stnc->tin_cnt; i++)
-			fprintf(f, "%12u", stnc->last_skblen[i]);
-		fprintf(f, "\n");
+		if(stnc->version < 4) {
+			fprintf(f, "  last_len");
+			for(i=0; i < stnc->tin_cnt; i++)
+				fprintf(f, "%12u", stnc->last_skblen[i]);
+			fprintf(f, "\n");
+		}
 
 		fprintf(f, "  max_len ");
 		for(i=0; i < stnc->tin_cnt; i++)


### PR DESCRIPTION
Don't show the last packet's length stat, since the qdisc is no longer collecting it.
