### PR TITLE
fix C99/C11 only warning

### DIFF
--- a/tc/q_cake.c
+++ b/tc/q_cake.c
@@ -41,7 +41,9 @@ static struct cake_preset presets[] = {
 
 static struct cake_preset *find_preset(char *argv)
 {
-	for (int i = 0; i < ARRAY_SIZE(presets); i++)
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(presets); i++)
 		if (!strcmp(argv, presets[i].name))
 			return &presets[i];
 	return NULL;


### PR DESCRIPTION
q_cake.c:44:2: error: for loop initial declarations are only allowed in C99 or C11 mode

Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>